### PR TITLE
Quick refactor to migrate project to pug from jade.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 build/
 node_modules/
 *.log
+
+# Unsure whether we should track the lock file for this project.
+yarn.lock

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,8 +9,8 @@ gulp.task('css',function() {
 });
 
 gulp.task('email', ['css'],function() {
-  return gulp.src('./templates/*.jade')
-    .pipe($.jade({pretty:true}))
+  return gulp.src('./templates/*.pug')
+    .pipe($.pug({pretty:true}))
     .pipe(gulp.dest('./build'))
     .pipe($.juice())
     .pipe(gulp.dest('./build'))

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "dependencies": {
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",
-    "gulp-jade": "^1.1.0",
     "gulp-juice": "^0.1.0",
     "gulp-load-plugins": "^1.2.2",
+    "gulp-pug": "^4.0.1",
     "gulp-rename": "^1.2.2",
     "gulp-stylus": "^2.3.1"
   },

--- a/templates/testing.pug
+++ b/templates/testing.pug
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+doctype html
 html(lang="en")
 head
   meta(charset="UTF-8")


### PR DESCRIPTION
Quick refactor to migrate project to pug from jade.

In the test template, I changed the doctype to match a format I'm more familiar with for pug templates.